### PR TITLE
Make multi type select look similar to multi region select

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -72,19 +72,17 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
 
                                             <div class="form-group col-lg-6 col-6">
                                                 <label>Types</label>
-                                                <select name="breedingTypeFilter1" autocomplete="off" class="custom-select" onchange="BreedingFilters.type1.value(Array.from(this.selectedOptions).map(o => Number(o.value))), Settings.setSettingByName(this.name, Array.from(this.selectedOptions).map(o => Number(o.value)))" multiple="true">
-                                                    <!-- ko foreach: Settings.getSetting('breedingTypeFilter1').options -->
-                                                    <option data-bind="attr: { value: Number($data.value), selected: Settings.getSetting('breedingTypeFilter1').isSelected($data.value) }, text: $data.text">Type</option>
-                                                    <!-- /ko -->
-                                                </select>
+                                                <knockout data-bind="template: {
+                                                    name: 'multiSettingTemplate',
+                                                    data: { setting: Settings.getSetting('breedingTypeFilter1') },
+                                                }" />
                                             </div>
                                             <div class="form-group col-md-6 col-6">
                                                 <label> </label>
-                                                <select name="breedingTypeFilter2" autocomplete="off" class="custom-select" onchange="BreedingFilters.type2.value(Array.from(this.selectedOptions).map(o => Number(o.value))), Settings.setSettingByName(this.name, Array.from(this.selectedOptions).map(o => Number(o.value)))" multiple="true">
-                                                    <!-- ko foreach: Settings.getSetting('breedingTypeFilter2').options -->
-                                                    <option data-bind="attr: { value: Number($data.value), selected: Settings.getSetting('breedingTypeFilter2').isSelected($data.value) }, text: $data.text">Type</option>
-                                                    <!-- /ko -->
-                                                </select>
+                                                <knockout data-bind="template: {
+                                                    name: 'multiSettingTemplate',
+                                                    data: { setting: Settings.getSetting('breedingTypeFilter2') },
+                                                }" />
                                             </div>
 
                                             <div class="form-group col-lg-6 col-6">

--- a/src/components/templates/multiSettingTemplate.html
+++ b/src/components/templates/multiSettingTemplate.html
@@ -1,0 +1,21 @@
+<!-- expects a MultiSetting to be passed in as setting -->
+<script type="text/html" id="multiSettingTemplate">
+    <div class="dropdown show">
+        <button type="button" class="text-left custom-select col-12 btn btn-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+            data-bind="text : $data.setting.displayValue()"
+        ></button>
+        <div class="border-secondary dropdown-menu col-12" style="max-height: 50vw; overflow: scroll">
+            <div class="dropdown-item" data-bind="click : function(){ $data.setting.toggleAll() }">
+                All
+            </div>
+            <div class="dropdown-divider"></div>
+            <!-- ko foreach : $data.setting.getValidOptions() -->
+                <div class="dropdown-item" data-bind="class : $parent.setting.isSelected($data.value) ? 'bg-success' : '',
+                    text : $data.text,
+                    click : function(){ $parent.setting.set([$data.value]) },
+                    event : { 'contextmenu' : () => { $parent.setting.toggle($data.value); return false; }
+                }"></div>
+            <!-- /ko-->
+        </div>
+    </div>
+</script>

--- a/src/index.html
+++ b/src/index.html
@@ -117,6 +117,7 @@
 @import "templates/pokemonGenderTemplate.html"
 @import "templates/pokemonAttackTemplate.html"
 @import "templates/pokemonGenderStatisticTemplate.html"
+@import "templates/multiSettingTemplate.html"
 
 <div id="game" class="container loading" data-bind="css: {'container': Settings.getSetting('gameDisplayStyle').observableValue() === 'standard3', 'container-fluid': Settings.getSetting('gameDisplayStyle').observableValue() !== 'standard3'}">
     <div class="row justify-content-center">

--- a/src/modules/settings/BaseSetting.ts
+++ b/src/modules/settings/BaseSetting.ts
@@ -51,6 +51,10 @@ export default abstract class BaseSetting<T, S> {
         return this.options.filter((opt) => opt.isUnlocked());
     }
 
+    getOption(value: S): SettingOption<S> {
+        return this.options.find((opt) => opt.value === value);
+    }
+
     get displayName(): string {
         if (!this.cachedTranslatedName) {
             this.cachedTranslatedName = App.translation.get(

--- a/src/modules/settings/MultiSetting.ts
+++ b/src/modules/settings/MultiSetting.ts
@@ -1,19 +1,18 @@
 import BaseSetting from './BaseSetting';
 
 export default class MultiSetting<T> extends BaseSetting<T[], T> {
-    private optionValues: T[];
+    private _optionValues: Set<T>;
+    private selectedValues = ko.pureComputed(() => {
+        return this.observableValue().reduce((set, v) => set.add(v), new Set<T>());
+    });
 
     validValue(value: T[]): boolean {
         if (!this.isUnlocked(value)) {
             return false;
         }
 
-        if (this.optionValues === undefined) {
-            this.optionValues = this.options.map((o) => o.value);
-        }
-
         for (let i = 0; i < value.length; i += 1) {
-            if (!this.optionValues.includes(value[i])) {
+            if (!this.optionValues.has(value[i])) {
                 return false;
             }
         }
@@ -22,6 +21,58 @@ export default class MultiSetting<T> extends BaseSetting<T[], T> {
     }
 
     protected isSelected(value: T): boolean {
-        return this.observableValue().includes(value);
+        return this.selectedValues().has(value);
+    }
+
+    public displayValue(): string {
+        const selected = this.observableValue();
+
+        if (selected.length === 0) {
+            return 'None';
+        }
+
+        if (selected.length === 1) {
+            return this.getOption(selected[0]).text;
+        }
+
+        if (selected.length === this.optionValues.size) {
+            return 'All';
+        }
+
+        return `${selected.length} Selected`;
+    }
+
+    public select(value: T) {
+        if (this.optionValues.has(value)) {
+            const newValue = [...this.observableValue(), value];
+            this.set(newValue);
+        }
+    }
+
+    public deselect(value: T) {
+        const newValue = this.observableValue().filter((v) => v !== value);
+        this.set(newValue);
+    }
+
+    public toggle(value: T) {
+        if (this.isSelected(value)) {
+            this.deselect(value);
+        } else {
+            this.select(value);
+        }
+    }
+
+    public toggleAll() {
+        const newValue = this.observableValue().length === this.optionValues.size
+            ? []
+            : [...this.optionValues];
+        this.set(newValue);
+    }
+
+    get optionValues(): Set<T> {
+        if (!this._optionValues) {
+            this._optionValues = this.options.reduce((set, o) => set.add(o.value), new Set<T>());
+        }
+        return this._optionValues;
     }
 }

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -225,7 +225,9 @@ Object.keys(BreedingFilters).forEach((key) => {
     }
     const filter = BreedingFilters[key];
     if (key === 'type1' || key === 'type2') {
-        Settings.add(new MultiSetting<string>(filter.optionName, filter.displayName, filter.options || [], filter.value()));
+        const setting = new MultiSetting<string>(filter.optionName, filter.displayName, filter.options || [], filter.value());
+        Settings.add(setting);
+        setting.observableValue.subscribe((val) => BreedingFilters[key].value(val));
     } else {
         Settings.add(new Setting<string>(filter.optionName, filter.displayName, filter.options || [], filter.value().toString()));
     }


### PR DESCRIPTION
Makes the multi type select in the breeding modal look like the region multiselect we have.
Right click to toggle selections, left click to pick just that option.

Didn't want to just push this change directly to your branch, so making a PR to your fork instead. Merging this will auto update your PR for this feature with the changes.


https://user-images.githubusercontent.com/4183969/236713775-96171354-803d-4987-9c1b-75a06406a7c4.mp4

Related to pokeclicker/pokeclicker#4046

